### PR TITLE
add factorization, preordering and pre-factorized solving (dgstrf and dgstrs)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -57,15 +57,15 @@ fn main() {
 }
 
 fn copy(source: &Path, destination: &Path, extension: &str) -> io::Result<()> {
-    for entry in try!(fs::read_dir(source)) {
-        let path = try!(entry).path();
+    for entry in fs::read_dir(source)? {
+        let path = entry?.path();
         if fs::metadata(&path).unwrap().is_dir() {
             continue;
         }
         match path.extension() {
             Some(name) if name == extension => match path.file_name() {
                 Some(name) => {
-                    try!(fs::copy(&path, destination.join(name)));
+                    fs::copy(&path, destination.join(name))?;
                 }
                 _ => {}
             },

--- a/src/slu_ddefs.rs
+++ b/src/slu_ddefs.rs
@@ -1,7 +1,8 @@
-use libc::{c_double, c_int};
+use libc::{c_double, c_int, c_void};
 
 use slu_util::*;
 use supermatrix::*;
+use superlu_enum_consts::*;
 
 extern "C" {
     pub fn dgssv(
@@ -38,6 +39,34 @@ extern "C" {
         stype: Stype_t,
         dtype: Dtype_t,
         mtype: Mtype_t,
+    );
+
+    pub fn dgstrf(
+        options: *mut superlu_options_t,
+        A: *mut SuperMatrix,
+        relax: c_int,
+        panel_size: c_int,
+        etree: *mut c_int,
+        work: *mut c_void,
+        lwork: c_int,
+        perm_c: *mut c_int,
+        perm_r: *mut c_int,
+        L: *mut SuperMatrix,
+        U: *mut SuperMatrix,
+        Glu: *mut GlobalLU_t,
+        stat: *mut SuperLUStat_t,
+        info: *mut c_int,
+    );
+
+    pub fn dgstrs (
+        trans: trans_t,
+        L: *mut SuperMatrix,
+        U: *mut SuperMatrix,
+        perm_c: *mut c_int,
+        perm_r: *mut c_int,
+        B: *mut SuperMatrix,
+        stat: *mut SuperLUStat_t,
+        info: *mut c_int,
     );
 
     pub fn doubleMalloc(n: c_int) -> *mut c_double;

--- a/src/slu_ddefs.rs
+++ b/src/slu_ddefs.rs
@@ -1,8 +1,8 @@
 use libc::{c_double, c_int, c_void};
 
 use slu_util::*;
-use supermatrix::*;
 use superlu_enum_consts::*;
+use supermatrix::*;
 
 extern "C" {
     pub fn dgssv(
@@ -58,7 +58,7 @@ extern "C" {
         info: *mut c_int,
     );
 
-    pub fn dgstrs (
+    pub fn dgstrs(
         trans: trans_t,
         L: *mut SuperMatrix,
         U: *mut SuperMatrix,

--- a/src/slu_util.rs
+++ b/src/slu_util.rs
@@ -39,6 +39,23 @@ pub struct superlu_options_t {
 
 #[derive(Clone, Copy)]
 #[repr(C)]
+pub struct ExpHeader {
+    pub size: c_int,
+    pub mem: *mut c_void,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct LU_stack_t {
+    pub size: c_int,
+    pub used: c_int,
+    pub top1: c_int,
+    pub top2: c_int,
+    pub array: *mut c_void,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
 pub struct SuperLUStat_t {
     pub panel_histo: *mut c_int,
     pub utime: *mut c_double,
@@ -48,6 +65,28 @@ pub struct SuperLUStat_t {
     pub expansions: c_int,
 }
 
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct GlobalLU_t {
+    pub xsup: *mut c_int,
+    pub supno: *mut c_int,
+    pub lsub: *mut c_int,
+    pub xlsub: *mut c_int,
+    pub lusup: *mut c_void,
+    pub xlusup: *mut c_int,
+    pub ucol: *mut c_void,
+    pub usub: *mut c_int,
+    pub xusub: *mut c_int,
+    pub nzlmax: c_int,
+    pub nzumax: c_int,
+    pub nzlumax: c_int,
+    pub n: c_int,
+    pub MemModel: LU_space_t,
+    pub num_expansions: c_int,
+    pub expanders: *mut ExpHeader,
+    pub stack: LU_stack_t,
+}
+
 extern "C" {
     pub fn Destroy_SuperMatrix_Store(A: *mut SuperMatrix);
     pub fn Destroy_CompCol_Matrix(A: *mut SuperMatrix);
@@ -55,8 +94,17 @@ extern "C" {
     pub fn Destroy_SuperNode_Matrix(A: *mut SuperMatrix);
     pub fn Destroy_CompCol_Permuted(A: *mut SuperMatrix);
     pub fn Destroy_Dense_Matrix(A: *mut SuperMatrix);
+    pub fn get_perm_c(ispec: c_int, A: *mut SuperMatrix, perm_c: *mut c_int);
     pub fn set_default_options(options: *mut superlu_options_t);
+    pub fn sp_preorder(
+        options: *mut superlu_options_t,
+        A: *mut SuperMatrix,
+        perm_c: *mut c_int,
+        etree: *mut c_int,
+        AC: *mut SuperMatrix,
+    );
     pub fn intMalloc(n: c_int) -> *mut c_int;
+    pub fn sp_ienv(ispec: c_int) -> c_int;
     pub fn superlu_free(addr: *mut c_void);
     pub fn StatInit(stat: *mut SuperLUStat_t);
     pub fn StatFree(stat: *mut SuperLUStat_t);

--- a/src/superlu_enum_consts.rs
+++ b/src/superlu_enum_consts.rs
@@ -54,6 +54,13 @@ pub enum IterRefine_t {
 
 #[derive(Clone, Copy)]
 #[repr(C)]
+pub enum LU_space_t {
+    SYSTEM,
+    USER,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
 pub enum norm_t {
     ONE_NORM,
     TWO_NORM,

--- a/tests/dgstrf.rs
+++ b/tests/dgstrf.rs
@@ -1,0 +1,206 @@
+extern crate superlu_sys as raw;
+extern crate libc;
+
+// https://github.com/copies/superlu/blob/master/EXAMPLE/superlu.c
+#[allow(non_snake_case)]
+#[test]
+fn test_dgstrf_dgstrs() {
+    use std::mem::uninitialized;
+    use std::slice::from_raw_parts_mut;
+    use libc::c_int;
+
+    use raw::*;
+    use raw::Dtype_t::*;
+    use raw::Mtype_t::*;
+    use raw::Stype_t::*;
+    use raw::colperm_t::*;
+    use raw::trans_t::*;
+    use raw::fact_t::*;
+
+    unsafe {
+        let (m, n, nnz) = (5, 5, 12);
+
+        let a = doubleMalloc(nnz);
+        assert!(!a.is_null());
+        {
+            let (s, u, p, e, r, l) = (19.0, 21.0, 16.0, 5.0, 18.0, 12.0);
+            let a = from_raw_parts_mut(a, nnz as usize);
+            a[0] = s;
+            a[1] = l;
+            a[2] = l;
+            a[3] = u;
+            a[4] = l;
+            a[5] = l;
+            a[6] = u;
+            a[7] = p;
+            a[8] = u;
+            a[9] = e;
+            a[10] = u;
+            a[11] = r;
+        }
+
+        let asub = intMalloc(nnz);
+        assert!(!asub.is_null());
+        {
+            let asub = from_raw_parts_mut(asub, nnz as usize);
+            asub[0] = 0;
+            asub[1] = 1;
+            asub[2] = 4;
+            asub[3] = 1;
+            asub[4] = 2;
+            asub[5] = 4;
+            asub[6] = 0;
+            asub[7] = 2;
+            asub[8] = 0;
+            asub[9] = 3;
+            asub[10] = 3;
+            asub[11] = 4;
+        }
+
+        let xa = intMalloc(n + 1);
+        assert!(!xa.is_null());
+        {
+            let xa = from_raw_parts_mut(xa, (n + 1) as usize);
+            xa[0] = 0;
+            xa[1] = 3;
+            xa[2] = 6;
+            xa[3] = 8;
+            xa[4] = 10;
+            xa[5] = 12;
+        }
+
+        let mut A: SuperMatrix = uninitialized();
+        dCreate_CompCol_Matrix(&mut A, m, n, nnz, a, asub, xa, SLU_NC, SLU_D, SLU_GE);
+
+        let nrhs = 1;
+        let rhs = doubleMalloc(m * nrhs);
+        assert!(!rhs.is_null());
+        {
+            let rhs = from_raw_parts_mut(rhs, (m * nrhs) as usize);
+            for i in 0..((m * nrhs) as usize) {
+                rhs[i] = 1.0;
+            }
+        }
+
+        let mut B: SuperMatrix = uninitialized();
+        dCreate_Dense_Matrix(&mut B, m, nrhs, rhs, m, SLU_DN, SLU_D, SLU_GE);
+
+        let perm_r = intMalloc(m);
+        assert!(!perm_r.is_null());
+
+        let perm_c = intMalloc(n);
+        assert!(!perm_c.is_null());
+
+        let mut options: superlu_options_t = uninitialized();
+        set_default_options(&mut options);
+        options.ColPerm = MMD_ATA;
+
+        let mut stat: SuperLUStat_t = uninitialized();
+        StatInit(&mut stat);
+
+        let mut L: SuperMatrix = uninitialized();
+        let mut U: SuperMatrix = uninitialized();
+
+        let mut info = 0;
+        poor_mans_dgssv(
+            &mut options,
+            &mut A,
+            perm_c,
+            perm_r,
+            &mut L,
+            &mut U,
+            &mut B,
+            &mut stat,
+            &mut info,
+        );
+
+        SUPERLU_FREE(rhs as *mut _);
+        SUPERLU_FREE(perm_r as *mut _);
+        SUPERLU_FREE(perm_c as *mut _);
+        Destroy_CompCol_Matrix(&mut A);
+        Destroy_SuperMatrix_Store(&mut B);
+        Destroy_SuperNode_Matrix(&mut L);
+        Destroy_CompCol_Matrix(&mut U);
+        StatFree(&mut stat);
+    }
+
+    // implementation of dgssv which leaves out some timing info,
+    // and which doesn't support NR format
+    //
+    // for testing dgstrf and dgstrs (as well as get_perm_c and sp_preorder)
+    unsafe fn poor_mans_dgssv(
+        options: &mut superlu_options_t,
+        A: &mut SuperMatrix,
+        perm_c: *mut c_int,
+        perm_r: *mut c_int,
+        L: &mut SuperMatrix,
+        U: &mut SuperMatrix,
+        B: &mut SuperMatrix,
+        stat: &mut SuperLUStat_t,
+        info: &mut c_int,
+    ) {
+        *info = 0;
+
+        assert_eq!(options.Fact as i32, DOFACT as i32);
+        assert_eq!(A.nrow, A.ncol);
+        assert!(A.nrow >= 0);
+        assert_eq!(A.Stype as i32, SLU_NC as i32);
+        assert_eq!(A.Dtype as i32, SLU_D as i32);
+        assert_eq!(A.Mtype as i32, SLU_GE as i32);
+        assert!(B.ncol >= 0);
+        // assert!((*(B.Store as *mut DNFormat)).lda >= std::cmp::max(0, A.nrow));
+        assert_eq!(B.Stype as i32, SLU_DN as i32);
+        assert_eq!(B.Dtype as i32, SLU_D as i32);
+        assert_eq!(B.Mtype as i32, SLU_GE as i32);
+
+        let permc_spec = options.ColPerm;
+        if permc_spec as i32 != MY_PERMC as i32 {
+            get_perm_c(permc_spec as _, A, perm_c);
+        }
+
+        let etree = intMalloc(A.ncol);
+
+        let mut AC: SuperMatrix = uninitialized();
+        sp_preorder(options, A, perm_c, etree, &mut AC);
+
+        let mut Glu: GlobalLU_t = uninitialized();
+        let panel_size = sp_ienv(1);
+        let relax = sp_ienv(2);
+        let work = std::ptr::null_mut();
+        let lwork = 0;
+        dgstrf(
+            options,
+            &mut AC,
+            relax,
+            panel_size,
+            etree,
+            work,
+            lwork,
+            perm_c,
+            perm_r,
+            L,
+            U,
+            &mut Glu,
+            stat,
+            info,
+        );
+
+        if *info == 0 {
+            dgstrs(
+                NOTRANS,
+                L,
+                U,
+                perm_c,
+                perm_r,
+                B,
+                stat,
+                info,
+            );
+        }
+
+        SUPERLU_FREE(etree as *mut _);
+        Destroy_CompCol_Permuted(&mut AC);
+
+        assert_eq!(*info, 0);
+    }
+}

--- a/tests/dgstrf.rs
+++ b/tests/dgstrf.rs
@@ -1,21 +1,21 @@
-extern crate superlu_sys as raw;
 extern crate libc;
+extern crate superlu_sys as raw;
 
 // https://github.com/copies/superlu/blob/master/EXAMPLE/superlu.c
 #[allow(non_snake_case)]
 #[test]
 fn test_dgstrf_dgstrs() {
+    use libc::c_int;
     use std::mem::MaybeUninit;
     use std::slice::from_raw_parts_mut;
-    use libc::c_int;
 
-    use raw::*;
+    use raw::colperm_t::*;
+    use raw::fact_t::*;
+    use raw::trans_t::*;
     use raw::Dtype_t::*;
     use raw::Mtype_t::*;
     use raw::Stype_t::*;
-    use raw::colperm_t::*;
-    use raw::trans_t::*;
-    use raw::fact_t::*;
+    use raw::*;
 
     unsafe {
         let (m, n, nnz) = (5, 5, 12);
@@ -70,7 +70,18 @@ fn test_dgstrf_dgstrs() {
         }
 
         let mut A = MaybeUninit::<SuperMatrix>::uninit();
-        dCreate_CompCol_Matrix(A.as_mut_ptr(), m, n, nnz, a, asub, xa, SLU_NC, SLU_D, SLU_GE);
+        dCreate_CompCol_Matrix(
+            A.as_mut_ptr(),
+            m,
+            n,
+            nnz,
+            a,
+            asub,
+            xa,
+            SLU_NC,
+            SLU_D,
+            SLU_GE,
+        );
         let mut A = A.assume_init();
 
         let nrhs = 1;
@@ -194,16 +205,7 @@ fn test_dgstrf_dgstrs() {
         let _ = Glu.assume_init();
 
         if *info == 0 {
-            dgstrs(
-                NOTRANS,
-                L,
-                U,
-                perm_c,
-                perm_r,
-                B,
-                stat,
-                info,
-            );
+            dgstrs(NOTRANS, L, U, perm_c, perm_r, B, stat, info);
         }
 
         SUPERLU_FREE(etree as *mut _);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -7,11 +7,11 @@ fn superlu() {
     use std::mem::MaybeUninit;
     use std::slice::from_raw_parts_mut;
 
-    use raw::*;
+    use raw::colperm_t::*;
     use raw::Dtype_t::*;
     use raw::Mtype_t::*;
     use raw::Stype_t::*;
-    use raw::colperm_t::*;
+    use raw::*;
 
     unsafe {
         let (m, n, nnz) = (5, 5, 12);
@@ -66,7 +66,18 @@ fn superlu() {
         }
 
         let mut A = MaybeUninit::<SuperMatrix>::uninit();
-        dCreate_CompCol_Matrix(A.as_mut_ptr(), m, n, nnz, a, asub, xa, SLU_NC, SLU_D, SLU_GE);
+        dCreate_CompCol_Matrix(
+            A.as_mut_ptr(),
+            m,
+            n,
+            nnz,
+            a,
+            asub,
+            xa,
+            SLU_NC,
+            SLU_D,
+            SLU_GE,
+        );
         let mut A = A.assume_init();
 
         let nrhs = 1;


### PR DESCRIPTION
Adds `dgstrf/dgstrs` and the other things that are needed in order to use them.

SuperLU does not include any examples that use `dgstrf`, so I had to get creative for my test.

I haven't yet gotten a chance to try using this in my own code base.  Chances are that I'll need to write a couple more bindings (at least for some of the `XYformat` types) before I can achieve what I want to with it. I'm more or less just putting this up for now to leave myself a nagging reminder to get back to this.

---

For some bizarre reason, `get_perm_c` takes an `int` instead of the `colperm_t` enum.  AIUI there's nothing we can do about this.  (the platform ABI is responsible for specifying how to pass and return C enums, and not all platforms may treat them as equivalent to `int`)

---

There's an extra commit to fix deprecation warnings.  I would have made a separate PR, but it touches some of the same lines so it would have conflicted with this one.