### PR TITLE
Compatibility issues with current rust and fortran versions resolved

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,10 @@
 name = "superlu-sys"
 version = "0.3.2"
 license = "Apache-2.0/MIT"
-authors = ["Ivan Ukhov <ivan.ukhov@gmail.com>"]
-description = "The package provides bindings to SuperLU."
+authors = ["Ivan Ukhov <ivan.ukhov@gmail.com>", "Henrik Stromberg <henrik@askdrq.com>"]
+description = "The package provides bindings to SuoerLU. Fork of superlu-sys by Ivan Ukov."
 documentation = "https://docs.rs/superlu-sys"
-homepage = "https://github.com/stainless-steel/superlu-sys"
-repository = "https://github.com/stainless-steel/superlu-sys"
+repository = "https://github.com/HenrikJStromberg/superlu-sys"
 readme = "README.md"
 categories = ["external-ffi-bindings", "science"]
 keywords = ["linear-algebra"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ links = "superlu"
 
 [dependencies]
 libc = "0.2"
-openblas-src = "0.10.8"
+openblas-src = { version = "0.10.8", features = ["cache"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ links = "superlu"
 
 [dependencies]
 libc = "0.2"
-openblas-src = "0.5"
+openblas-src = "0.10.8"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # superlu-sys [![Package][package-img]][package-url] [![Documentation][documentation-img]][documentation-url] [![Build][build-img]][build-url]
 
 The package provides bindings to [SuperLU].
+If is a fork of superlu-sys by Ivan Ukov.
 
 ## Contribution
 

--- a/build.rs
+++ b/build.rs
@@ -57,19 +57,17 @@ fn main() {
 }
 
 fn copy(source: &Path, destination: &Path, extension: &str) -> io::Result<()> {
-    for entry in try!(fs::read_dir(source)) {
-        let path = try!(entry).path();
-        if fs::metadata(&path).unwrap().is_dir() {
+    for entry in fs::read_dir(source)? {
+        let path = entry?.path();
+        if fs::metadata(&path)?.is_dir() {
             continue;
         }
-        match path.extension() {
-            Some(name) if name == extension => match path.file_name() {
-                Some(name) => {
-                    try!(fs::copy(&path, destination.join(name)));
+        if let Some(name) = path.extension() {
+            if name == extension {
+                if let Some(name) = path.file_name() {
+                    fs::copy(&path, destination.join(name))?;
                 }
-                _ => {}
-            },
-            _ => {}
+            }
         }
     }
     Ok(())

--- a/src/supermatrix.rs
+++ b/src/supermatrix.rs
@@ -1,3 +1,4 @@
+use std::slice;
 use libc::{c_int, c_void};
 
 pub type int_t = c_int;
@@ -49,6 +50,37 @@ pub struct SuperMatrix {
     pub Store: *mut c_void,
 }
 
+impl SuperMatrix {
+    pub fn data_as_vec(&self) -> Option<Vec<f64>> {
+        match self.Stype {
+            Stype_t::SLU_DN => {}
+            _ => {return None}
+        }
+
+        match self.Dtype {
+            Dtype_t::SLU_D => {}
+            _ => {return None}
+        }
+
+        unsafe {
+            let store = self.Store as *const DNformat;
+            if store.is_null() {
+                return None;
+            }
+
+            let dn_format = &*store;
+            let nnz = (self.nrow * self.ncol) as usize;
+            match self.Dtype {
+                Dtype_t::SLU_D => {
+                    let values = slice::from_raw_parts(dn_format.nzval as *const f64, nnz);
+                    Some(values.to_vec())
+                },
+                _ => {None}
+            }
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct NCformat {
@@ -56,4 +88,11 @@ pub struct NCformat {
     pub nzval: *mut c_void,
     pub rowind: *mut int_t,
     pub colptr: *mut int_t,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct DNformat {
+    pub lda: int_t,
+    pub nzval: *mut c_void,
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -69,7 +69,7 @@ fn superlu() {
             xa[5] = 12;
         }
 
-        let mut A: SuperMatrix = unsafe { MaybeUninit::zeroed().assume_init() };
+        let mut A: SuperMatrix = MaybeUninit::zeroed().assume_init();
 
         dCreate_CompCol_Matrix(&mut A, m, n, nnz, a, asub, xa, SLU_NC, SLU_D, SLU_GE);
 
@@ -83,7 +83,7 @@ fn superlu() {
             }
         }
 
-        let mut B: SuperMatrix = unsafe { MaybeUninit::zeroed().assume_init() };
+        let mut B: SuperMatrix = MaybeUninit::zeroed().assume_init();
         dCreate_Dense_Matrix(&mut B, m, nrhs, rhs, m, SLU_DN, SLU_D, SLU_GE);
 
         let perm_r = intMalloc(m);
@@ -92,15 +92,15 @@ fn superlu() {
         let perm_c = intMalloc(n);
         assert!(!perm_c.is_null());
 
-        let mut options: superlu_options_t = unsafe { MaybeUninit::zeroed().assume_init() };
+        let mut options: superlu_options_t = MaybeUninit::zeroed().assume_init();
         set_default_options(&mut options);
         options.ColPerm = NATURAL;
 
-        let mut stat: SuperLUStat_t = unsafe { MaybeUninit::zeroed().assume_init() };
+        let mut stat: SuperLUStat_t = MaybeUninit::zeroed().assume_init();
         StatInit(&mut stat);
 
-        let mut L: SuperMatrix = unsafe { MaybeUninit::zeroed().assume_init() };
-        let mut U: SuperMatrix = unsafe { MaybeUninit::zeroed().assume_init() };
+        let mut L: SuperMatrix = MaybeUninit::zeroed().assume_init();
+        let mut U: SuperMatrix = MaybeUninit::zeroed().assume_init();
 
         let mut info = 0;
         dgssv(

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -11,7 +11,7 @@ use raw::*;
 // https://github.com/copies/superlu/blob/master/EXAMPLE/superlu.c
 #[allow(non_snake_case)]
 #[test]
-fn superlu() {
+fn test_valid() {
     use raw::Dtype_t::*;
     use raw::Mtype_t::*;
     use raw::Stype_t::*;
@@ -68,6 +68,82 @@ fn superlu() {
             xa[4] = 10;
             xa[5] = 12;
         }
+
+        let mut A: SuperMatrix = MaybeUninit::zeroed().assume_init();
+
+        dCreate_CompCol_Matrix(&mut A, m, n, nnz, a, asub, xa, SLU_NC, SLU_D, SLU_GE);
+
+        let nrhs = 1;
+        let rhs = doubleMalloc(m * nrhs);
+        assert!(!rhs.is_null());
+        {
+            let rhs = from_raw_parts_mut(rhs, (m * nrhs) as usize);
+            for i in 0..((m * nrhs) as usize) {
+                rhs[i] = 1.0;
+            }
+        }
+
+        let mut B: SuperMatrix = MaybeUninit::zeroed().assume_init();
+        dCreate_Dense_Matrix(&mut B, m, nrhs, rhs, m, SLU_DN, SLU_D, SLU_GE);
+
+        let perm_r = intMalloc(m);
+        assert!(!perm_r.is_null());
+
+        let perm_c = intMalloc(n);
+        assert!(!perm_c.is_null());
+
+        let mut options: superlu_options_t = MaybeUninit::zeroed().assume_init();
+        set_default_options(&mut options);
+        options.ColPerm = NATURAL;
+
+        let mut stat: SuperLUStat_t = MaybeUninit::zeroed().assume_init();
+        StatInit(&mut stat);
+
+        let mut L: SuperMatrix = MaybeUninit::zeroed().assume_init();
+        let mut U: SuperMatrix = MaybeUninit::zeroed().assume_init();
+
+        let mut info = 0;
+        dgssv(
+            &mut options,
+            &mut A,
+            perm_c,
+            perm_r,
+            &mut L,
+            &mut U,
+            &mut B,
+            &mut stat,
+            &mut info,
+        );
+
+        SUPERLU_FREE(rhs as *mut _);
+        SUPERLU_FREE(perm_r as *mut _);
+        SUPERLU_FREE(perm_c as *mut _);
+        Destroy_CompCol_Matrix(&mut A);
+        Destroy_SuperMatrix_Store(&mut B);
+        Destroy_SuperNode_Matrix(&mut L);
+        Destroy_CompCol_Matrix(&mut U);
+        StatFree(&mut stat);
+    }
+}
+
+#[allow(non_snake_case)]
+#[test]
+fn test_singular() {
+    use raw::Dtype_t::*;
+    use raw::Mtype_t::*;
+    use raw::Stype_t::*;
+    use raw::colperm_t::*;
+
+    unsafe {
+        let (m, n, nnz) = (5, 5, 0);
+
+        let a = doubleMalloc(nnz);
+        assert!(!a.is_null());
+        let asub = intMalloc(nnz);
+        assert!(!asub.is_null());
+
+        let xa = intMalloc(n + 1);
+        assert!(!xa.is_null());
 
         let mut A: SuperMatrix = MaybeUninit::zeroed().assume_init();
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,10 +1,12 @@
 extern crate superlu_sys as raw;
 
+use std::mem::MaybeUninit;
+
 // https://github.com/copies/superlu/blob/master/EXAMPLE/superlu.c
 #[allow(non_snake_case)]
 #[test]
 fn superlu() {
-    use std::mem::uninitialized;
+    use std::mem::MaybeUninit;
     use std::slice::from_raw_parts_mut;
 
     use raw::*;
@@ -65,7 +67,8 @@ fn superlu() {
             xa[5] = 12;
         }
 
-        let mut A: SuperMatrix = uninitialized();
+        let mut A: SuperMatrix = unsafe { MaybeUninit::zeroed().assume_init() };
+
         dCreate_CompCol_Matrix(&mut A, m, n, nnz, a, asub, xa, SLU_NC, SLU_D, SLU_GE);
 
         let nrhs = 1;
@@ -78,7 +81,7 @@ fn superlu() {
             }
         }
 
-        let mut B: SuperMatrix = uninitialized();
+        let mut B: SuperMatrix = unsafe { MaybeUninit::zeroed().assume_init() };
         dCreate_Dense_Matrix(&mut B, m, nrhs, rhs, m, SLU_DN, SLU_D, SLU_GE);
 
         let perm_r = intMalloc(m);
@@ -87,15 +90,15 @@ fn superlu() {
         let perm_c = intMalloc(n);
         assert!(!perm_c.is_null());
 
-        let mut options: superlu_options_t = uninitialized();
+        let mut options: superlu_options_t = unsafe { MaybeUninit::zeroed().assume_init() };
         set_default_options(&mut options);
         options.ColPerm = NATURAL;
 
-        let mut stat: SuperLUStat_t = uninitialized();
+        let mut stat: SuperLUStat_t = unsafe { MaybeUninit::zeroed().assume_init() };
         StatInit(&mut stat);
 
-        let mut L: SuperMatrix = uninitialized();
-        let mut U: SuperMatrix = uninitialized();
+        let mut L: SuperMatrix = unsafe { MaybeUninit::zeroed().assume_init() };
+        let mut U: SuperMatrix = unsafe { MaybeUninit::zeroed().assume_init() };
 
         let mut info = 0;
         dgssv(


### PR DESCRIPTION
When trying to use the crate openBLAS failed to link with gfortran on all my systems. I diagnosed the issue to be caused by use of an outdated version of openblas-src. After updating I found, that superlu-sys uses mem::uninitialized in its test which is depricated. I swaped it for MaybeUninit. After these changes cargo test runs on all systems I have tested on.